### PR TITLE
Implement status argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ minimize(Math.cos, {guess: -3});
 
 ## Usage
 
-#### `require('minimize-golden-section-1d')(f[, options])`
+#### `require('minimize-golden-section-1d')(f[, options[, status]])`
 
-Given function `f` of one `Number`-valued variable, computes a local minimum. On successful completion, returns the value of the argument that minimizes `f` (note that this may either be a local or global minimum in the provided range). If the algorithm fails (e.g. NaN encountered or unconstrained divergence of the argument to `Infinity`), returns `NaN`. If tolerance is not met, returns best answer.
+Given function `f` of one `Number`-valued variable, computes a local minimum. On successful completion, returns the value of the argument that minimizes `f` (note that this may either be a local or global minimum in the provided range). If the algorithm fails (i.e. if max iterations exceeded, `NaN` encountered, or unbounded divergence of the argument to `Infinity`), returns `NaN`.
 
 If bounds are provided, this module proceeds immediately with golden section search. If upper, lower or both bounds are not provided, the algorithm will make use of an initial guess (a provided guess or just one of the bounds if that's all it has) and expand the search range until a minimum is bracketed.
 
@@ -43,9 +43,16 @@ If bounds are provided, this module proceeds immediately with golden section sea
 - `tolerance [=1e-8]`: Convergence tolerance. Algorithm continues until search interval is smaller than `tolerance`.
 - `lowerBound [=-Infinity]`: Lower bound of the search interval
 - `upperBound [=Infinity]`: Upper bound of the search interval
-- `maxIter [=100]`: Maximum number of iterations for either bracketing or search phase.
-- `guess [=0]`: initial guess for unconstrained minimization. Unused unless both `upperBound` and `lowerBound` are not provided.
-- `initialIncrement [=1]`: Initial interval by which to expand the search interval for unconstrained minimization. Unused unless both `upperBound` and `lowerBound` are not provided.
+- `maxIterations [=100]`: Maximum number of iterations for either bracketing or search phase.
+- `guess [=0]`: initial guess for unbounded minimization. Unused unless both `upperBound` and `lowerBound` are not provided.
+- `initialIncrement [=1]`: Initial interval by which to expand the search interval for unbounded minimization. Unused unless both `upperBound` and `lowerBound` are not provided.
+
+##### Status:
+If `status` object is provided, the following outputs are written in place:
+- `status.converged` (`Boolean`): `true` if algorithm succeeded
+- `status.iterations` (`Number`): number of iterations
+- `status.minimum` (`Number`): minimum value of the function achieved before exiting, whether the algorithm converged or not
+- `status.argmin` (`Number`): best guess of argmin achieved before exiting, whether the algorithm converged or not.
 
 ## License
 &copy; 2015 [Scijs](https://github.com/scijs). MIT License.

--- a/src/bracket-minimum.js
+++ b/src/bracket-minimum.js
@@ -2,7 +2,7 @@
 
 module.exports = bracketMinimum;
 
-function bracketMinimum (f, x0, dx, xMin, xMax, maxIter) {
+function bracketMinimum (bounds, f, x0, dx, xMin, xMax, maxIter) {
   // If either size is unbounded (=infinite), Expand the guess
   // range until we either bracket a minimum or until we reach the bounds:
   var fU, fL, fMin, n, xL, xU, bounded;
@@ -46,9 +46,13 @@ function bracketMinimum (f, x0, dx, xMin, xMax, maxIter) {
     dx *= n < 4 ? 2 : Math.exp(n * 0.5);
 
     if (!isFinite(dx)) {
-      return [-Infinity, Infinity];
+      bounds[0] = -Infinity;
+      bounds[1] = Infinity;
+      return bounds;
     }
   }
 
-  return [xL, xU];
+  bounds[0] = xL;
+  bounds[1] = xU;
+  return bounds;
 }

--- a/src/golden-section-minimize.js
+++ b/src/golden-section-minimize.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var phiRatio = 2 / (1 + Math.sqrt(5));
+var PHI_RATIO = 2 / (1 + Math.sqrt(5));
 
 module.exports = goldenSectionMinimize;
 
-function goldenSectionMinimize (f, xL, xU, tol, maxIter) {
+function goldenSectionMinimize (f, xL, xU, tol, maxIterations, status) {
   var xF, fF;
-  var n = 0;
-  var x1 = xU - phiRatio * (xU - xL);
-  var x2 = xL + phiRatio * (xU - xL);
+  var iteration = 0;
+  var x1 = xU - PHI_RATIO * (xU - xL);
+  var x2 = xL + PHI_RATIO * (xU - xL);
   // Initial bounds:
   var f1 = f(x1);
   var f2 = f(x2);
@@ -22,32 +22,38 @@ function goldenSectionMinimize (f, xL, xU, tol, maxIter) {
   var xU0 = xU;
 
   // Simple, robust golden section minimization:
-  while (++n < maxIter && Math.abs(xU - xL) > tol) {
+  while (++iteration < maxIterations && Math.abs(xU - xL) > tol) {
     if (f2 > f1) {
       xU = x2;
       x2 = x1;
       f2 = f1;
-      x1 = xU - phiRatio * (xU - xL);
+      x1 = xU - PHI_RATIO * (xU - xL);
       f1 = f(x1);
     } else {
       xL = x1;
       x1 = x2;
       f1 = f2;
-      x2 = xL + phiRatio * (xU - xL);
+      x2 = xL + PHI_RATIO * (xU - xL);
       f2 = f(x2);
     }
   }
 
-  if (n === maxIter) {
-    return 0.5 * (f1 + f2);
-  }
-
-  if (isNaN(f2) || isNaN(f1)) {
-    return NaN;
-  }
-
   xF = 0.5 * (xU + xL);
   fF = 0.5 * (f1 + f2);
+
+  if (status) {
+    status.iterations = iteration;
+    status.argmin = xF;
+    status.minimum = fF;
+    status.converged = true;
+  }
+
+  if (isNaN(f2) || isNaN(f1) || iteration === maxIterations) {
+    if (status) {
+      status.converged = false;
+    }
+    return NaN;
+  }
 
   if (f10 < fF) {
     return xL0;


### PR DESCRIPTION
This PR implements an optional `status` argument to return information when it doesn't succeed, thus avoiding obnoxious overloading of outputs or the need for try/catch. In particular:

- `iterations`: # iterations
- `converged`: true|false
- `argmin`: best guess at argmin (even if not converged 🤷‍♂️ )
- `minimum`: best guess at minimum (even if not converged 🤷‍♂️ )

And if it doesn't converge, it the function itself returns `NaN` so that you hopefully figure out you need to examine the status.

Will be major version bump.

Addresses #2. /cc @fasiha @jaspervdg 